### PR TITLE
Dont limit user to a forced version of certain build tools

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pkg-config  # [unix]
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - make {{ make }}   
+    - make
   host:
     - gettext  # [unix]
     - libogg {{ libogg }} 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-   number: 1
+   number: 2
    string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
 
 requirements:


### PR DESCRIPTION
User shouldnt be forced to have specific version of some general tools (e.g. make), if we are not truly using version-specific features. We arent requiring this consistently across many feedstocks.