### PR TITLE
Removed libgcc-ng and libstdcxx-ng pins as they are no longer needed

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     # https://github.com/NVIDIA/DALI_deps/blob/main/patches/0001-libFLAC-bitreader.c-Fix-out-of-bounds-read.patch
     - 0001-libFLAC-bitreader.c-Fix-out-of-bounds-read.patch
 build:
-   number: 1
+   number: 2
    string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
 
 requirements:
@@ -28,15 +28,9 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake {{ cmake }}
     - make
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
   host:
     - gettext  # [unix]
     - libogg {{ libogg }}
-    # Use pins to control cos6/cos7 match
-    - libgcc-ng  {{ libgcc }}
-    - libstdcxx-ng  {{ libstdcxx }}
   run:
     - libogg                  # versioning handled by run_exports
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,9 +28,15 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake {{ cmake }}
     - make
+    # Use pins to control cos6/cos7 match
+    - libgcc-ng  {{ libgcc }}                               # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}                         # [x86_64 and c_compiler_version == "7.2.*"]
   host:
     - gettext  # [unix]
     - libogg {{ libogg }}
+    # Use pins to control cos6/cos7 match
+    - libgcc-ng  {{ libgcc }}                               # [x86_64 and c_compiler_version == "7.2.*"]
+    - libstdcxx-ng  {{ libstdcxx }}                         # [x86_64 and c_compiler_version == "7.2.*"]
   run:
     - libogg                  # versioning handled by run_exports
 


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Removed pins for libgcc-ng and libstdcxx-ng as they are no longer needed.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
